### PR TITLE
Adjusting imports to work with Redmine 5, Rails 6, zeitwerk

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,14 +1,18 @@
 require 'redmine'
 
-ActiveSupport::Reloader.to_prepare do
-  require_dependency 'redmine_base_stimulusjs/hooks'
+if Rails.version > '6.0'
+  required File.expand_path('lib/redmine_base_stimulusjs/hooks.rb', __dir__)
+else
+  ActiveSupport::Reloader.to_prepare do
+    require_dependency 'redmine_base_stimulusjs/hooks'
+  end
 end
 
 Redmine::Plugin.register :redmine_base_stimulusjs do
   name 'Redmine Base StimulusJS plugin'
   author 'Vincent ROBERT'
   description 'This is a plugin for Redmine'
-  version '1.1.1'
+  version '1.1.2'
   url 'https://github.com/nanego/redmine_base_stimulusjs'
   author_url 'contact@vincent-robert.com'
 end


### PR DESCRIPTION
This little patch makes the plugin work with latest Redmine and should provide full backward compatibility (though not tested)