### PR TITLE
Update hooks.rb and compatibility with redmine 5.0.2

### DIFF
--- a/lib/redmine_base_stimulusjs/hooks.rb
+++ b/lib/redmine_base_stimulusjs/hooks.rb
@@ -1,4 +1,4 @@
-module RedmineBaseStimulusJS
+module RedmineBaseStimulusjs
   class Hooks < Redmine::Hook::ViewListener
     def view_layouts_base_html_head(context)
       tags = javascript_include_tag("stimulusjs-1.1.1.js", :plugin => "redmine_base_stimulusjs")


### PR DESCRIPTION
I suggest to change module RedmineBaseStimulusJS to module RedmineBaseStimulusjs

Under Redmine 5.0.2 it doesn't work with the Zeitwerk loader: 

	/usr/local/bundle/gems/zeitwerk-2.6.0/lib/zeitwerk/loader/helpers.rb:127:in `const_get': uninitialized constant RedmineBaseStimulusjs::Hooks (NameError)
  
		parent.const_get(cname, false)
  
            ^^^^^^^^^^
  
	from /usr/local/bundle/gems/zeitwerk-2.6.0/lib/zeitwerk/loader/helpers.rb:127:in `cget'